### PR TITLE
feat: output a debugging userscript

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,6 @@ node_modules
 /.nyc_output
 /coverage
 /docs
+/dist/debugging.user.js
 bun.lockb
 package-lock.json

--- a/rollup-plugin-debug-library-userscript.mjs
+++ b/rollup-plugin-debug-library-userscript.mjs
@@ -6,6 +6,7 @@ export default function debugLibraryUserScriptOutputPlugin() {
 // ==UserScript==
 // @name         Internet Roadtrip Framework debugging
 // @match        https://*/*
+// @noframes
 // @run-at       document-start
 // @require      ${libraryUrl}
 // ==/UserScript==

--- a/rollup-plugin-debug-library-userscript.mjs
+++ b/rollup-plugin-debug-library-userscript.mjs
@@ -1,0 +1,49 @@
+import { Buffer } from 'node:buffer';
+
+/** @return {import('rollup').Plugin} */
+export default function debugLibraryUserScriptOutputPlugin() {
+	const renderUserscript = ({ libraryUrl }) => `
+// ==UserScript==
+// @name         Internet Roadtrip Framework debugging
+// @match        https://*/*
+// @run-at       document-start
+// @require      ${libraryUrl}
+// ==/UserScript==
+
+(async () => {
+	debugger;
+})();
+	`.trim() + '\n';
+
+  return {
+    name: 'debug-library-userscript-output',
+
+    generateBundle(_outputOptions, bundle) {
+			let fileName = 'test.user.js';
+			let outputSourceCode = '';
+
+			for (const assetOrChunk of Object.values(bundle)) {
+				if (assetOrChunk.type === 'asset') {
+					continue;
+				}
+
+				const chunk = /** @type {import('rollup').OutputChunk} */ (assetOrChunk);
+				if (!chunk.isEntry) {
+					continue;
+				}
+
+				fileName = chunk.fileName;
+				outputSourceCode += chunk.code + '\n';
+			}
+
+			const outputBase64Data = Buffer.from(outputSourceCode).toString('base64');
+			const outputBase64Url = `data:text/javascript;base64,${outputBase64Data}`;
+
+			this.emitFile({
+				type: 'asset',
+				fileName,
+				source: renderUserscript({ libraryUrl: outputBase64Url })
+			});
+    }
+  };
+}

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,4 +1,5 @@
 import { defineExternal, definePlugins } from '@gera2ld/plaid-rollup';
+import debugLibraryUserscriptOutput from './rollup-plugin-debug-library-userscript.mjs';
 import { defineConfig } from 'rollup';
 import pkg from './package.json' with { type: 'json' };
 
@@ -50,6 +51,34 @@ export default defineConfig([
 			banner: `/*! ${pkg.name}@${pkg.version} | ${pkg.license} License */\nvar s,i,t;i=null==(s=this.IRF||{})?void 0:s.version,t="${pkg.version}",(void 0===i||i.startsWith(t+"-")||!t.startsWith(i+"-")&&-1===i.localeCompare(t,void 0,{numeric:!0,sensitivity:"case",caseFirst:"upper"}))&&`,
 			extend: true,
 			esModule: false,
+		},
+	},
+	{
+		input: 'src/index.ts',
+		plugins: definePlugins({
+			minimize: true,
+			postcss: {
+				inject: false,
+				minimize: true,
+				modules: {
+					generateScopedName: 'irf-[hash:base64:6]',
+				},
+			},
+			replaceValues: {
+				'process.env.VERSION': pkg.version,
+			},
+		}),
+		output: {
+			format: 'iife',
+			file: `dist/debugging.user.js`,
+			name: 'IRF',
+			indent: false,
+			banner: `/*! ${pkg.name}@${pkg.version} | ${pkg.license} License */\nvar s,i,t;i=null==(s=this.IRF||{})?void 0:s.version,t="${pkg.version}",(void 0===i||i.startsWith(t+"-")||!t.startsWith(i+"-")&&-1===i.localeCompare(t,void 0,{numeric:!0,sensitivity:"case",caseFirst:"upper"}))&&`,
+			extend: true,
+			esModule: false,
+			plugins: [
+				debugLibraryUserscriptOutput()
+			]
 		},
 	},
 ]);


### PR DESCRIPTION
Nice for testing the framework instead of having to copy the output to the browser's console.

Currently the output userscript just has a `debugger;` statement in it. But I imagine this could be expanded to read from a (gitignored?) template file so we can setup the tests we want to do.